### PR TITLE
handle clicks that last longer than 150ms

### DIFF
--- a/typeahead.js
+++ b/typeahead.js
@@ -95,6 +95,7 @@ proto.show = function () {
 proto.hide = function () {
     this.menu.addClass('hidden');
     this.shown = false;
+    this.mousedown = false;
     return this;
 }
 
@@ -208,6 +209,8 @@ proto.listen = function () {
       .on('keydown', self.keydown.bind(self))
 
     self.menu
+      .on('mousedown', self.mousedown.bind(self))
+      .on('mouseup', self.mouseup.bind(self))
       .on('click', self.click.bind(self))
       .on('mouseenter', 'li', self.mouseenter.bind(self))
 }
@@ -273,9 +276,19 @@ proto.keyup = function (e) {
     e.preventDefault()
 }
 
+proto.mousedown = function (e) {
+    this.mousedown = true;
+}
+proto.mouseup = function (e) {
+    this.mousedown = false;
+}
 proto.blur = function (e) {
     var self = this;
-    setTimeout(function () { self.hide() }, 150);
+    setTimeout(function () {
+        if (!self.mousedown) {
+            self.hide();
+        }
+    }, 150);
 }
 
 proto.click = function (e) {


### PR DESCRIPTION
bug: when you mousedown on a typeahead option, it blurs the text field which starts a 150ms timer to hide the menu, if you don't mouseup before the timer finishes, the click doesn't go through
