### PR TITLE
fixes wrong position when window is scrolled

### DIFF
--- a/typeahead.js
+++ b/typeahead.js
@@ -65,6 +65,11 @@ proto.show = function () {
     var scroll = 0
     var parent = self.element[0]
     while (parent = parent.parentElement) {
+        // prevent adding window scroll
+        if (parent.tagName.toLowerCase() === 'html') {
+            continue;
+        }
+        
         scroll += parent.scrollTop
     }
 


### PR DESCRIPTION
Before the scrollTop of the `<html>` tag was also added, which does not work for absolute positioning and was always placing the list way above the input.